### PR TITLE
Improve mobile range selection UX

### DIFF
--- a/client/src/pages/__tests__/calendar.test.tsx
+++ b/client/src/pages/__tests__/calendar.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@/components/CalendarGrid", () => ({
   default: (props: {
     onDayClick?: (date: Date, transactions: ParsedTransaction[]) => void;
     transactions: ParsedTransaction[];
+    touchRangeEnabled?: boolean;
   }) => {
     calendarGridProps(props);
     const { onDayClick } = props;

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -12,7 +12,7 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { useToast } from "@/hooks/use-toast";
 import { buildRecurringIcs, filterRecurringTransactionsForMonth } from "@/lib/icsExport";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
-import { Download, Filter } from "lucide-react";
+import { CalendarRange, Download, Filter } from "lucide-react";
 import RangeSummaryDrawer from "@/components/RangeSummaryDrawer";
 import {
   buildRangeCsv,
@@ -34,6 +34,7 @@ export default function CalendarPage({ transactions }: CalendarPageProps) {
   const [selectedDayTransactions, setSelectedDayTransactions] = useState<ParsedTransaction[]>([]);
   const [selectedRange, setSelectedRange] = useState<DateRange | null>(null);
   const [isRangeDrawerOpen, setRangeDrawerOpen] = useState(false);
+  const [isMobileRangeMode, setMobileRangeMode] = useState(false);
   const [filters, setFilters] = useState<FilterState>({
     categories: [],
     minAmount: "",
@@ -43,6 +44,7 @@ export default function CalendarPage({ transactions }: CalendarPageProps) {
   });
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const { toast } = useToast();
+  const isTouchRangeEnabled = isDesktop || isMobileRangeMode;
 
   const handlePrevMonth = () => {
     setCurrentDate(
@@ -58,6 +60,17 @@ export default function CalendarPage({ transactions }: CalendarPageProps) {
 
   const handleToday = () => {
     setCurrentDate(new Date());
+  };
+
+  const handleToggleMobileRangeMode = () => {
+    setMobileRangeMode((prev) => {
+      const next = !prev;
+      if (!prev) {
+        setSelectedDate(null);
+        setSelectedDayTransactions([]);
+      }
+      return next;
+    });
   };
 
   const handleDayClick = (date: Date, dayTransactions: ParsedTransaction[]) => {
@@ -289,6 +302,25 @@ export default function CalendarPage({ transactions }: CalendarPageProps) {
                         {EXPORT_TOOLTIP}
                       </TooltipContent>
                     </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant={isMobileRangeMode ? "default" : "outline"}
+                          size="sm"
+                          onClick={handleToggleMobileRangeMode}
+                          aria-pressed={isMobileRangeMode}
+                          data-testid="button-mobile-range-mode"
+                          className="gap-2"
+                        >
+                          <CalendarRange className="h-4 w-4" />
+                          {isMobileRangeMode ? "Range on" : "Select range"}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" align="center" className="max-w-[220px] text-center">
+                        Tap once to set a start date, then tap another day to finish.
+                        You can also drag while your finger is down.
+                      </TooltipContent>
+                    </Tooltip>
                     <Sheet>
                       <SheetTrigger asChild>
                         <Button
@@ -324,6 +356,7 @@ export default function CalendarPage({ transactions }: CalendarPageProps) {
                   onDayClick={handleDayClick}
                   selectedRange={selectedRange}
                   onRangeSelect={handleRangeSelect}
+                  touchRangeEnabled={isTouchRangeEnabled}
                 />
               </div>
             ) : (
@@ -366,6 +399,7 @@ export default function CalendarPage({ transactions }: CalendarPageProps) {
                       onDayClick={handleDayClick}
                       selectedRange={selectedRange}
                       onRangeSelect={handleRangeSelect}
+                      touchRangeEnabled={isTouchRangeEnabled}
                     />
                   </div>
                 </ResizablePanel>


### PR DESCRIPTION
### **User description**
## Summary
- add a mobile-only range selection toggle that enables touch-driven ranges without disrupting desktop drag behaviour
- enhance `CalendarGrid` with pending touch range tracking, window-level pointer move handling, and support for the new toggle
- adjust the calendar page test double to accept the new prop surface

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eff7d3b53c832ab2c8790ad32dc967


___

### **PR Type**
Enhancement


___

### **Description**
- Add mobile-specific range selection toggle with touch-driven interaction

- Implement pending touch range tracking and window-level pointer move handling

- Enhance drag state management to support both mouse and touch pointer types

- Add visual feedback for pending touch range selection on mobile devices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User taps toggle"] --> B["Mobile range mode enabled"]
  B --> C["First tap sets start date"]
  C --> D["Second tap completes range"]
  D --> E["Range summary displayed"]
  B --> F["Drag gesture supported"]
  F --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CalendarGrid.tsx</strong><dd><code>Implement touch-driven range selection with pending state tracking</code></dd></summary>
<hr>

client/src/components/CalendarGrid.tsx

<ul><li>Add <code>touchRangeEnabled</code> prop to control mobile range selection behavior<br> <li> Implement <code>pendingTouchStart</code> state for tracking first touch in range <br>selection<br> <li> Extract <code>updateDragHover</code> callback for shared pointer move logic<br> <li> Add window-level <code>pointermove</code> listener for continuous drag tracking<br> <li> Enhance <code>finalizeSelection</code> to handle touch-specific range completion <br>logic<br> <li> Add <code>touch-pan-y</code> CSS class to prevent horizontal scroll interference<br> <li> Update pointer event handlers to distinguish mouse vs touch <br>interactions</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/25/files#diff-21951eede0429c75ba742a17cf83f34e7271d1683c3a3455b537d1f9325ecf98">+144/-43</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>calendar.tsx</strong><dd><code>Add mobile range mode toggle and state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/pages/calendar.tsx

<ul><li>Add <code>isMobileRangeMode</code> state and toggle button with <code>CalendarRange</code> icon<br> <li> Compute <code>isTouchRangeEnabled</code> based on desktop breakpoint or mobile mode<br> <li> Pass <code>touchRangeEnabled</code> prop to <code>CalendarGrid</code> component<br> <li> Clear selected date when entering mobile range mode<br> <li> Add tooltip explaining tap-to-select-range interaction pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/25/files#diff-d2bb6d0791ee2656ed7ea39cdac9d2d054e1b5af360c9f58139862a861e6e5a3">+35/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calendar.test.tsx</strong><dd><code>Update test mock to accept new prop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/pages/__tests__/calendar.test.tsx

<ul><li>Add <code>touchRangeEnabled</code> prop to <code>CalendarGrid</code> mock component interface</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/25/files#diff-68d8aceeddcd61d63907723aa1255d1fe20865578622b47b7f1c1d9f68a9cede">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

