### PR TITLE
feat: show export modal in centered dialog

### DIFF
--- a/client/src/components/ExportModal.tsx
+++ b/client/src/components/ExportModal.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import type { RecurringSeries } from "@shared/schema";
-import { Sheet, SheetContent, SheetTitle, SheetDescription } from "@/components/ui/sheet";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { DEFAULT_CURRENCY_SYMBOL, formatCurrency } from "@/lib/transactionUtils";
 import { selectSeriesForMonth } from "@/lib/recurrenceDetection";
@@ -100,14 +107,16 @@ export default function ExportModal({
     seriesForMonth.every((entry) => selected.has(entry.id));
 
   return (
-    <Sheet open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <SheetContent className="flex h-full flex-col overflow-hidden">
-        <SheetTitle>Export Recurring Transactions</SheetTitle>
-        <SheetDescription>
-          Select recurring transaction series detected for all data. One event will be
-          generated per series for {monthLabel}.
-        </SheetDescription>
-        <div className="mt-4 flex items-center justify-between gap-2">
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="flex max-h-[85vh] flex-col gap-4 overflow-hidden sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Export Recurring Transactions</DialogTitle>
+          <DialogDescription>
+            Select recurring transaction series detected for all data. One event will be
+            generated per series for {monthLabel}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center justify-between gap-2">
           <span className="text-sm text-muted-foreground">Exporting for {monthLabel}</span>
           <Button
             variant="ghost"
@@ -118,56 +127,58 @@ export default function ExportModal({
             {allSelected ? "Unselect all" : "Select all"}
           </Button>
         </div>
-        <div className="mt-2 min-h-0 flex-1 overflow-auto pr-1">
+        <div className="min-h-[120px] flex-1 overflow-auto rounded-md border border-border/40 pr-1">
           {seriesForMonth.length === 0 ? (
-            <p className="p-2 text-sm text-muted-foreground">
+            <p className="p-3 text-sm text-muted-foreground">
               No recurring transactions detected for this month.
             </p>
           ) : (
-            seriesForMonth.map((entry) => {
-              const representative = entry.representative;
-              const amountLabel = formatCurrency(
-                representative.amount,
-                representative.currencySymbol ?? DEFAULT_CURRENCY_SYMBOL
-              );
-              return (
-                <label
-                  key={entry.id}
-                  className="flex items-center gap-3 rounded-md p-3 hover:bg-muted"
-                >
-                  <input
-                    aria-label={`select-series-${entry.id}`}
-                    type="checkbox"
-                    checked={selected.has(entry.id)}
-                    onChange={() => toggle(entry.id)}
-                  />
-                  <div className="flex-1">
-                    <div className="flex items-baseline justify-between gap-2">
-                      <span className="font-medium">
-                        {representative.source?.name ?? representative.description}
-                      </span>
-                      <span className="text-sm font-semibold tabular-nums text-muted-foreground">
-                        {amountLabel}
-                      </span>
+            <div className="divide-y">
+              {seriesForMonth.map((entry) => {
+                const representative = entry.representative;
+                const amountLabel = formatCurrency(
+                  representative.amount,
+                  representative.currencySymbol ?? DEFAULT_CURRENCY_SYMBOL
+                );
+                return (
+                  <label
+                    key={entry.id}
+                    className="flex cursor-pointer items-center gap-3 p-3 hover:bg-muted"
+                  >
+                    <input
+                      aria-label={`select-series-${entry.id}`}
+                      type="checkbox"
+                      checked={selected.has(entry.id)}
+                      onChange={() => toggle(entry.id)}
+                    />
+                    <div className="flex-1">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span className="font-medium">
+                          {representative.source?.name ?? representative.description}
+                        </span>
+                        <span className="text-sm font-semibold tabular-nums text-muted-foreground">
+                          {amountLabel}
+                        </span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {formatMonthRange(entry)}
+                      </div>
                     </div>
-                    <div className="text-xs text-muted-foreground">
-                      {formatMonthRange(entry)}
-                    </div>
-                  </div>
-                </label>
-              );
-            })
+                  </label>
+                );
+              })}
+            </div>
           )}
         </div>
-        <div className="mt-4 flex items-center justify-end gap-2">
+        <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={isGenerating}>
             Cancel
           </Button>
           <Button onClick={handleExport} disabled={isGenerating || selected.size === 0}>
             {isGenerating ? "Generating…" : "Export"}
           </Button>
-        </div>
-      </SheetContent>
-    </Sheet>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-md",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};


### PR DESCRIPTION
### **User description**
## Summary
- replace the recurring export slide-in sheet with a centered dialog that matches the desired modal presentation
- keep the selection UX intact while tightening spacing and scroll behaviour for long recurring-series lists
- add a shared Radix dialog primitive so future modals no longer rely on the sheet component for popovers

## Testing
- pnpm typecheck
- pnpm test


___

### **PR Type**
Enhancement


___

### **Description**
- Replace Sheet component with centered Dialog for export modal

- Add new Radix dialog primitive component for reusable modals

- Improve UX with better spacing, scrolling, and visual hierarchy

- Add divider styling and cursor pointer to recurring series list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Sheet["Sheet Component<br/>slide-in"] -->|replaced by| Dialog["Dialog Component<br/>centered modal"]
  Dialog -->|uses| DialogPrimitive["Radix Dialog<br/>Primitive"]
  ExportModal["ExportModal<br/>Component"] -->|refactored with| Dialog
  ExportModal -->|improved UX| Styling["Better spacing<br/>& scrolling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExportModal.tsx</strong><dd><code>Refactor export modal from sheet to dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/ExportModal.tsx

<ul><li>Replaced Sheet imports with Dialog component imports<br> <li> Updated modal structure to use DialogHeader, DialogFooter, and <br>DialogContent<br> <li> Enhanced list container with border, rounded corners, and min-height <br>constraints<br> <li> Wrapped recurring series items in a divide-y container for visual <br>separation<br> <li> Added cursor-pointer class to labels and improved spacing throughout<br> <li> Removed rounded-md from individual items, now applied to container</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/36/files#diff-b272f382ac09f69328f7f53499000f82402c389463e9eca62d0d080f36ce7e79">+58/-47</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dialog.tsx</strong><dd><code>Add Radix dialog primitive wrapper component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/ui/dialog.tsx

<ul><li>Created new Dialog component wrapper around Radix UI dialog primitive<br> <li> Implemented DialogOverlay with backdrop blur and fade animations<br> <li> Added DialogContent with centered positioning and zoom/slide <br>animations<br> <li> Included DialogHeader, DialogFooter, DialogTitle, and <br>DialogDescription components<br> <li> Added close button with Cross2Icon in top-right corner<br> <li> Exported all dialog subcomponents for reusable modal patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/36/files#diff-4709db13b9e10ac4ec85f48f919f5ca9518783f0430c2b7dd61697d614e6746d">+102/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

