### PR TITLE
Fix ICS timezone export handling

### DIFF
--- a/client/src/components/CalendarExportButton.tsx
+++ b/client/src/components/CalendarExportButton.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+import { Download } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface CalendarExportButtonProps {
+  onClick: () => void;
+  tooltip: ReactNode;
+  testId?: string;
+}
+
+export const CalendarExportButton = ({
+  onClick,
+  tooltip,
+  testId = "button-export-ics",
+}: CalendarExportButtonProps) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <span className="inline-flex">
+        <Button variant="outline" size="sm" onClick={onClick} data-testid={testId}>
+          <Download className="w-4 h-4 mr-2" />
+          Export
+        </Button>
+      </span>
+    </TooltipTrigger>
+    <TooltipContent side="bottom" align="end">
+      {tooltip}
+    </TooltipContent>
+  </Tooltip>
+);
+

--- a/client/src/lib/__tests__/icsExport.test.ts
+++ b/client/src/lib/__tests__/icsExport.test.ts
@@ -123,6 +123,47 @@ describe("buildRecurringIcs", () => {
     );
   });
 
+  it("formats DTSTART/DTEND using the provided timezone", () => {
+    const occurrences = [
+      createTransaction({
+        id: "rent-jan",
+        date: new Date("2024-01-03T00:00:00Z"),
+        amount: -1800,
+        description: "Rent",
+        currencySymbol: "€",
+      }),
+      createTransaction({
+        id: "rent-feb",
+        date: new Date("2024-02-03T00:00:00Z"),
+        amount: -1800,
+        description: "Rent",
+        currencySymbol: "€",
+      }),
+      createTransaction({
+        id: "rent-mar",
+        date: new Date("2024-03-03T00:00:00Z"),
+        amount: -1800,
+        description: "Rent",
+        currencySymbol: "€",
+      }),
+    ];
+
+    const series = buildSeriesFixture("rent-series", occurrences);
+
+    const result = buildRecurringIcs([series], {
+      monthDate: new Date(2024, 0, 1),
+      timezone: "America/Los_Angeles",
+    });
+
+    expect(result.icsText).toContain(
+      "DTSTART;TZID=America/Los_Angeles:20240102T000000"
+    );
+    expect(result.icsText).toContain(
+      "DTEND;TZID=America/Los_Angeles:20240103T000000"
+    );
+    expect(result.icsText).toContain("RRULE:FREQ=MONTHLY;BYMONTHDAY=2");
+  });
+
   it("reuses a stable UID for the same series across months", () => {
     const occurrences = [
       createTransaction({ id: "salary-jan", date: new Date(2024, 0, 25), amount: 2500, category: "Income", description: "Salary" }),

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -5,6 +5,7 @@ import CalendarGrid from "@/components/CalendarGrid";
 import InsightsSidebar from "@/components/InsightsSidebar";
 import FilterPanel, { type FilterState } from "@/components/FilterPanel";
 import DayDetailPanel from "@/components/DayDetailPanel";
+import { CalendarExportButton } from "@/components/CalendarExportButton";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -17,8 +18,8 @@ import {
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useToast } from "@/hooks/use-toast";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
-import { Download, Filter } from "lucide-react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Filter } from "lucide-react";
 import RangeSummaryDrawer from "@/components/RangeSummaryDrawer";
 import {
   buildRangeCsv,
@@ -228,24 +229,10 @@ export default function CalendarPage({ transactions, onRequestExport }: Calendar
                     />
                   </div>
                   <div className="flex items-center gap-2">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={handleRequestExport}
-                            data-testid="button-export-ics"
-                          >
-                            <Download className="w-4 h-4 mr-2" />
-                            Export
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" align="end">
-                        {EXPORT_TOOLTIP}
-                      </TooltipContent>
-                    </Tooltip>
+                    <CalendarExportButton
+                      onClick={handleRequestExport}
+                      tooltip={EXPORT_TOOLTIP}
+                    />
                     <Sheet>
                       <SheetTrigger asChild>
                         <Button
@@ -302,24 +289,10 @@ export default function CalendarPage({ transactions, onRequestExport }: Calendar
                           onToday={handleToday}
                         />
                       </div>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={handleRequestExport}
-                              data-testid="button-export-ics"
-                            >
-                              <Download className="w-4 h-4 mr-2" />
-                              Export
-                            </Button>
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" align="end">
-                          {EXPORT_TOOLTIP}
-                        </TooltipContent>
-                      </Tooltip>
+                      <CalendarExportButton
+                        onClick={handleRequestExport}
+                        tooltip={EXPORT_TOOLTIP}
+                      />
                     </div>
                     <CalendarGrid
                       currentDate={currentDate}

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -57,6 +57,7 @@ export const clamp = (value: number, lower: number, upper: number): number => {
   return Math.min(Math.max(value, lower), upper);
 };
 
+// FNV-1a hash keeps identifier generation stable without exposing raw values.
 export const hashString = (value: string): string => {
   let hash = 0x811c9dc5;
   for (let index = 0; index < value.length; index += 1) {


### PR DESCRIPTION
### **User description**
## Summary
- derive DTSTART/DTEND from timezone-aligned midnights so ICS exports respect overrides
- reuse a shared calendar export button across layouts to keep tooltip and styling consistent
- cover the timezone branch in buildRecurringIcs with a regression test

## Testing
- pnpm test -- --run icsExport


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix ICS timezone export to derive DTSTART/DTEND from timezone-aligned midnights

- Replace local datetime formatting with timezone-aware date extraction using Intl.DateTimeFormat

- Extract reusable CalendarExportButton component to eliminate duplication

- Add regression test covering timezone-specific date formatting in recurring ICS exports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ICS Export Logic"] -->|"Use Intl.DateTimeFormat"| B["Timezone-Aware Date Extraction"]
  B -->|"Calculate Midnights"| C["Correct DTSTART/DTEND"]
  D["Duplicate Export Buttons"] -->|"Extract Component"| E["CalendarExportButton"]
  E -->|"Reuse in Layouts"| F["Calendar Page"]
  G["Test Coverage"] -->|"Add Regression Test"| H["Timezone Branch Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>icsExport.ts</strong><dd><code>Implement timezone-aware date formatting for ICS exports</code>&nbsp; </dd></summary>
<hr>

client/src/lib/icsExport.ts

<ul><li>Replace <code>formatDateAsLocalDateTime</code> with timezone-aware <br><code>extractDatePartsForTimezone</code> using Intl.DateTimeFormat<br> <li> Implement <code>getTimezoneDateFormatter</code> with caching for performance<br> <li> Replace <code>addLocalDays</code> with <code>addPlainDays</code> that operates on date parts<br> <li> Update <code>buildMonthlyRule</code> to accept timezone parameter and extract day <br>from timezone-aligned date<br> <li> Refactor DTSTART/DTEND calculation to use timezone-aligned midnights <br>instead of local time</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/38/files#diff-8aafb5d3080a87dfff45c240780058265db1e45455ff03074488c748589fd425">+65/-52</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>icsExport.test.ts</strong><dd><code>Add timezone formatting regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/lib/__tests__/icsExport.test.ts

<ul><li>Add regression test for timezone-specific DTSTART/DTEND formatting<br> <li> Test with America/Los_Angeles timezone to verify date shifts across <br>timezones<br> <li> Verify RRULE correctly uses timezone-aligned day of month</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/38/files#diff-2bea9a8ba678d193c0938b307f6bb7787412f78f54870f022cdc845894a84aa6">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CalendarExportButton.tsx</strong><dd><code>Extract reusable calendar export button component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/CalendarExportButton.tsx

<ul><li>Create new reusable CalendarExportButton component with tooltip <br>support<br> <li> Accept onClick handler, tooltip content, and optional testId props<br> <li> Encapsulate Download icon, button styling, and tooltip presentation</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/38/files#diff-234cee192b7db24ce31d2d0b62c467812f14879aee9d8cca7a57244d2967f7a0">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>calendar.tsx</strong><dd><code>Replace duplicate export buttons with shared component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/pages/calendar.tsx

<ul><li>Replace duplicate inline export button implementations with <br>CalendarExportButton component<br> <li> Remove redundant Tooltip, TooltipContent, TooltipTrigger, and Download <br>imports<br> <li> Apply component in both desktop and mobile layout sections<br> <li> Maintain consistent tooltip and styling across layouts</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/38/files#diff-d2bb6d0791ee2656ed7ea39cdac9d2d054e1b5af360c9f58139862a861e6e5a3">+11/-38</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Document hash function purpose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

shared/utils.ts

<ul><li>Add explanatory comment for FNV-1a hash algorithm usage in identifier <br>generation</ul>


</details>


  </td>
  <td><a href="https://github.com/Quisharoo/revolut-calendar/pull/38/files#diff-f687ce8896a9437e316e29e3021f6b7285d2aacfd631613e69a8ce200101014b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

